### PR TITLE
Fix the centroid add method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ codecov = { repository = "MnO2/t-digest" }
 
 [dependencies]
 ordered-float = "1.0"
+serde = { package = "serde", version = "1.0", optional = true, default-features = false }
+
+[features]
+use_serde = ["serde", "serde/derive", "ordered-float/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 
 #[cfg(feature = "use_serde")]
-use serde::{Serialize,Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Centroid implementation to the cluster mentioned in the paper.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,15 +68,15 @@ impl Centroid {
         self.weight.into_inner()
     }
 
-    pub fn add(&mut self, mut sum: f64, weight: f64) -> f64 {
+    pub fn add(&mut self, sum: f64, weight: f64) -> f64 {
         let weight_: f64 = self.weight.into_inner();
         let mean_: f64 = self.mean.into_inner();
 
-        sum += weight_ + mean_;
+        let new_sum: f64 = sum + weight_ * mean_;
         let new_weight: f64 = weight_ + weight;
         self.weight = OrderedFloat::from(new_weight);
-        self.mean = OrderedFloat::from(sum / new_weight);
-        sum
+        self.mean = OrderedFloat::from(new_sum / new_weight);
+        new_sum
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,12 @@
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 
+#[cfg(feature = "use_serde")]
+use serde::{Serialize,Deserialize};
+
 /// Centroid implementation to the cluster mentioned in the paper.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub struct Centroid {
     mean: OrderedFloat<f64>,
     weight: OrderedFloat<f64>,
@@ -91,6 +95,7 @@ impl Default for Centroid {
 
 /// T-Digest to be operated on.
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
 pub struct TDigest {
     centroids: Vec<Centroid>,
     max_size: usize,


### PR DESCRIPTION
The current implementation modifies the passed-in sum variable
as well as returning its value, unlike the C++ implementation
in folly, where the original sum variable is not modified due
to the pass-by-value convention.

Also, in the current rust implementation the weigth and the mean
are added instead of multiplied.

* This is the current implementation:
```rust
    pub fn add(&mut self, mut sum: f64, weight: f64) -> f64 {
        let weight_: f64 = self.weight.into_inner();
        let mean_: f64 = self.mean.into_inner();

        sum += weight_ + mean_;
        let new_weight: f64 = weight_ + weight;
        self.weight = OrderedFloat::from(new_weight);
        self.mean = OrderedFloat::from(sum / new_weight);
        sum
    }
```

* Here is the corresponding function in the folly implementation:
```c++
    double TDigest::Centroid::add(double sum, double weight) {
        sum += (mean_ * weight_);
        weight_ += weight;
        mean_ = sum / weight_;
        return sum;
    }
```

* And this is the proposed implementation:
```rust
    pub fn add(&mut self, sum: f64, weight: f64) -> f64 {
        let weight_: f64 = self.weight.into_inner();
        let mean_: f64 = self.mean.into_inner();

        let new_sum: f64 = sum + weight_ * mean_;
        let new_weight: f64 = weight_ + weight;
        self.weight = OrderedFloat::from(new_weight);
        self.mean = OrderedFloat::from(new_sum / new_weight);
        new_sum
    }
```

* Test program:
```rust
use tdigest::TDigest;

    fn main() {
        let vals = vec![1.0,1.0,1.0,2.0,1.0,1.0];
        let mut t = TDigest::new_with_size(10);

        for v in vals {
            t = t.merge_unsorted(vec![v]);
        }

        println!("P50: {}\nP95: {}", t.estimate_quantile(0.50), t.estimate_quantile(0.95));
    }
```

* Result without patch:
    P50: 5
    P95: 2

* Result with patch:
    P50: 1
    P95: 2