### PR TITLE
Add support for high frequency live observations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,37 +3,361 @@
 version = 3
 
 [[package]]
-name = "autocfg"
-version = "0.1.5"
+name = "anes"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "num-traits"
-version = "0.2.8"
+name = "atty"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "ordered-float"
-version = "2.8.0"
+name = "num-traits"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "ordered-float"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
 dependencies = [
  "num-traits",
  "serde",
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.6"
+name = "os_str_bytes"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
- "unicode-xid",
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -44,6 +368,64 @@ checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -66,26 +448,160 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.8"
+name = "serde_json"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661641ea2aa15845cddeb97dad000d22070bb5c1fb456b96c1cba883ec691e92"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "tdigest"
 version = "0.2.3"
 dependencies = [
+ "criterion",
  "ordered-float",
  "serde",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.0"
+name = "textwrap"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,24 @@ keywords = ["tdigest", "percentile", "statistics"]
 edition = "2021"
 exclude = ["/benches/**", "/.travis.yml"]
 
+[lib]
+bench = false
+
+[[bench]]
+name = "benches"
+path = "src/benches/mod.rs"
+harness = false
+
 [badges]
 travis-ci = { repository = "MnO2/t-digest" }
 codecov = { repository = "MnO2/t-digest" }
 
 [dependencies]
-ordered-float = "2.0"
+ordered-float = "3.4"
 serde = { package = "serde", version = "1.0", optional = true, default-features = false }
+
+[dev-dependencies]
+criterion = { version = "0.4" }
 
 [features]
 use_serde = ["serde", "serde/derive", "ordered-float/serde"]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,18 @@ let percentage: f64 = (expected - ans).abs() / expected;
 
 assert!(percentage < 0.01);
 ```
+
+Or, if you want to report with controlled memory and do not already have
+all of your values collected in a vector:
+```rust
+use tdigest::online::OnlineTdigest;
+
+let t = OnlineTdigest::default();
+
+// You can record observations on any thread. The amortized cost
+// is a few tens of nanoseconds.
+(1..1_000_000).for_each(|i| t.observe(i))
+
+// You can get() or reset() at any time. This gives you a TDigest.
+let digest = t.get();
+```

--- a/src/benches/mod.rs
+++ b/src/benches/mod.rs
@@ -1,0 +1,7 @@
+mod tdigest_bench;
+
+use criterion::{criterion_group, criterion_main};
+use tdigest_bench::bench;
+
+criterion_group!(tdigest_bench, bench);
+criterion_main!(tdigest_bench);

--- a/src/benches/tdigest_bench.rs
+++ b/src/benches/tdigest_bench.rs
@@ -1,0 +1,32 @@
+use criterion::{black_box, Criterion};
+
+pub fn bench(c: &mut Criterion) {
+    // For online recording, 1 observation is typically encountered at a time.
+    c.bench_function("observe 1 via merge", |b| {
+        let mut digest = tdigest::TDigest::default();
+        let mut i = 0.0;
+        b.iter(|| {
+            digest = digest.merge_sorted(black_box(vec![i]));
+            i += 1.0;
+        })
+    });
+
+    // For online recording, 1 observation is typically encountered at a time.
+    c.bench_function("observe 1 via online wrapper", |b| {
+        let digest = tdigest::online::OnlineTdigest::default();
+        let mut i = 0.0;
+        b.iter(|| {
+            digest.observe(black_box(i));
+            i += 1.0;
+        })
+    });
+
+    c.bench_function("observe 1 via online wrapper &mut", |b| {
+        let mut digest = tdigest::online::OnlineTdigest::default();
+        let mut i = 0.0;
+        b.iter(|| {
+            digest.observe_mut(black_box(i));
+            i += 1.0;
+        })
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@
 //! assert!(percentage < 0.01);
 //! ```
 
+pub mod online;
+
 use ordered_float::OrderedFloat;
 use std::cmp::Ordering;
 
@@ -106,6 +108,7 @@ pub struct TDigest {
 }
 
 impl TDigest {
+    /// Create a new t-digest with a maximum centroid count. 100 is the traditional recommendation.
     pub fn new_with_size(max_size: usize) -> Self {
         TDigest {
             centroids: Vec::new(),
@@ -117,6 +120,7 @@ impl TDigest {
         }
     }
 
+    /// Create an explicit TDigest. You probably want TDigest::new_with_size instead.
     pub fn new(centroids: Vec<Centroid>, sum: f64, count: f64, max: f64, min: f64, max_size: usize) -> Self {
         if centroids.len() <= max_size {
             TDigest {
@@ -182,6 +186,7 @@ impl TDigest {
 }
 
 impl Default for TDigest {
+    /// Create a new t-digest with a maximum centroid count. Per tradition, 100 max centroids are used by default.
     fn default() -> Self {
         TDigest {
             centroids: Vec::new(),
@@ -400,7 +405,7 @@ impl TDigest {
         let mut compressed: Vec<Centroid> = Vec::with_capacity(max_size);
 
         let mut k_limit: f64 = 1.0;
-        let mut q_limit_times_count: f64 = Self::k_to_q(k_limit, max_size as f64) * (count as f64);
+        let mut q_limit_times_count: f64 = Self::k_to_q(k_limit, max_size as f64) * count;
 
         let mut iter_centroids = centroids.iter_mut();
         let mut curr = iter_centroids.next().unwrap();
@@ -419,7 +424,7 @@ impl TDigest {
                 sums_to_merge = 0.0;
                 weights_to_merge = 0.0;
                 compressed.push(curr.clone());
-                q_limit_times_count = Self::k_to_q(k_limit, max_size as f64) * (count as f64);
+                q_limit_times_count = Self::k_to_q(k_limit, max_size as f64) * count;
                 k_limit += 1.0;
                 curr = centroid;
             }
@@ -430,7 +435,7 @@ impl TDigest {
         compressed.shrink_to_fit();
         compressed.sort();
 
-        result.count = OrderedFloat::from(count as f64);
+        result.count = OrderedFloat::from(count);
         result.min = min;
         result.max = max;
         result.centroids = compressed;

--- a/src/online.rs
+++ b/src/online.rs
@@ -1,0 +1,169 @@
+use std::sync::Mutex;
+
+use crate::TDigest;
+
+/// For use with monitoring, when you are recording a single value at a time.
+/// Handles amortizing the merge into your tdigest to reduce the latency per
+/// observation.
+///
+/// You should use this instead of a bare TDigest when you need your
+/// observations to be as quick as possible, and you only occasionally read
+/// the digest. (e.g., to periodically log or emit to a metrics backend)
+///
+/// Sharable between concurrent threads, the critical internal section is
+/// protected via a mutex. You do not need mut to modify the internal state,
+/// but mut will reduce the cost slightly.
+///
+/// Once in a while it will collapse your observations into the backing digest.
+/// This merge is a more expensive observation, but it's less common. Reducing
+/// the amortization size 25% to 24 costs 20% additional latency. Increasing
+/// may reduce further, but we're around 43ns per observation with amortization
+/// 32. This is a fine improvement over the baseline of 850ns doing a
+/// per-observation merge.
+///
+/// The extra bookkeeping in this struct costs about 20ns. By deferring the merge,
+/// the cost of each merge to each observation is about 20ns as well, for a budget
+/// of 40-50ns. Your server might be faster than this.
+#[derive(Default)]
+pub struct OnlineTdigest {
+    state: Mutex<State>,
+}
+
+#[derive(Default)]
+struct State {
+    current: TDigest,
+    amortized_observations: [f64; 32],
+    i: u8,
+}
+
+impl OnlineTdigest {
+    /// Get the current tdigest, merging any outstanding observations.
+    pub fn get(&self) -> TDigest {
+        let mut state = self.state.lock().expect("lock should never fail");
+        get_snapshot(&mut state)
+    }
+
+    /// Get the current tdigest, merging any outstanding observations.
+    pub fn get_mut(&mut self) -> TDigest {
+        let state = self
+            .state
+            .get_mut()
+            .expect("with &mut self the mutex should be unlocked");
+        get_snapshot(state)
+    }
+
+    /// Retrieves the current tdigest, merging any outstanding observations and resetting.
+    pub fn reset(&self) -> TDigest {
+        let mut state = self.state.lock().expect("lock should never fail");
+        let snapshot = get_snapshot(&mut state);
+        state.current = Default::default();
+        snapshot
+    }
+
+    /// Retrieves the current tdigest, merging any outstanding observations and resetting.
+    pub fn reset_mut(&mut self) -> TDigest {
+        let state = self
+            .state
+            .get_mut()
+            .expect("with &mut self the mutex should be unlocked");
+        get_snapshot_and_reset(state)
+    }
+
+    /// Record 1 occurrence of a value, to be merged into a
+    /// tdigest later.
+    #[inline] // saves 2-3 nanoseconds according to benchmark results
+    pub fn observe(&self, observation: impl Into<f64>) {
+        let mut state = self.state.lock().expect("lock should never fail");
+        record_observation(&mut state, observation.into());
+    }
+
+    /// Record 1 occurrence of a value, to be merged into a
+    /// tdigest later.
+    /// Use this when you can, as the observe() function costs **around
+    /// 30% more (9-11ns more on my laptop)** than using &mut.
+    #[inline]
+    pub fn observe_mut(&mut self, observation: impl Into<f64>) {
+        let state = self
+            .state
+            .get_mut()
+            .expect("with &mut self the mutex should be unlocked");
+        record_observation(state, observation.into());
+    }
+}
+
+#[inline]
+fn get_snapshot_and_reset(state: &mut State) -> TDigest {
+    let snapshot = get_snapshot(state);
+    state.current = Default::default();
+    snapshot
+}
+
+#[inline]
+fn get_snapshot(state: &mut State) -> TDigest {
+    flush_state(state);
+    state.current.clone()
+}
+
+#[inline]
+fn record_observation(mut state: &mut State, observation: f64) {
+    let index = state.i as usize;
+    state.amortized_observations[index] = observation;
+    state.i += 1;
+    if state.i == state.amortized_observations.len() as u8 {
+        flush_state(state)
+    }
+}
+
+#[inline]
+fn flush_state(state: &mut State) {
+    if state.i < 1 {
+        return;
+    }
+    let new = state
+        .current
+        .merge_unsorted(Vec::from(&state.amortized_observations[0..state.i as usize]));
+    state.current = new;
+    state.i = 0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OnlineTdigest;
+
+    #[test]
+    fn p999() {
+        let digester = OnlineTdigest::default();
+        for i in 0..10_001 {
+            digester.observe(i as f64);
+        }
+        let digest = digester.reset();
+        assert_eq!(0.0, digest.min());
+        assert_eq!(10_000.0, digest.max());
+        assert_eq!(10_001.0, digest.count());
+        let error = 9_990.0 - digest.estimate_quantile(0.999);
+        assert!(-1.0 < error && error < 1.0);
+    }
+
+    #[test]
+    fn reset() {
+        let digester = OnlineTdigest::default();
+        digester.observe(1.23);
+        digester.reset();
+        let digest = digester.reset();
+        assert_eq!(0.0, digest.count());
+    }
+
+    #[test]
+    fn directly_observable_types() {
+        let digester = OnlineTdigest::default();
+        // Anything that can be turned Into<u64> can be passed straight in.
+        digester.observe(1.23);
+        digester.observe(1);
+        digester.observe(1.23_f32);
+        digester.observe(1.23_f64);
+        digester.observe(1_i32);
+        digester.observe(1_u32);
+        // 64 bit integers will require a manual cast to f64
+        (1..100).for_each(|i| digester.observe(i))
+    }
+}


### PR DESCRIPTION
* add benchmark for tdigest merge
* update ordered-float dependency
* add OnlineTdigest

 # Background
I want to use t-digests with grpc services. In a service rpc handler,
you typically encounter each measured event once per invocation.
Using the TDigest that is in `lib` for this is very costly unless
updates to the digest are amortized. Doing this manually for each
digest is onerous and error-prone; and it seems like a fairly common
need (in my experience).

 # The idea
Goals:
* very simple to use
* minimize memory usage
* minimize extra allocations (going to use this with object-pool so maximize the effect)
* minimize latency recording 1 observation of a value
* allow reporting at any time
* Send and Sync, internal mutability
* less than 1/10 the latency of updating the digest each call

TDigest seems fine - its mutation functions are a little more "functional"
and return a copy. That's nice, but can be expensive when you're using it
as a tool to control memory cost in a server!
So let's add a wrapper around it: Support retrieving a TDigest at any time,
but make it convenient to record a number with optimally low overhead.

Storing the amortized records in an array lowers the allocation burden versus
a vector, and lets us bypass clear() to reuse. It costs bookkeeping for 1 index
but promises to give the most benefit possible from an object_pool::Pool and it
lowers the cost of the periodic flush to the backing tdigest (though only a small
amount).

 # Testing
Updating a TDigest for each invocation of a service api costs around
840ns according to some simple Criterion benchmarking:
```
observe 1 via merge     time:   [832.06 ns 836.12 ns 840.71 ns]
                        change: [-0.3243% +1.6089% +3.2155%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
```

 # Results
for plain usage like:
```rust
let digest = tdigest::online::OnlineTdigest::default();

[...]

for i in 1..1000 {
  digest.observe(i);
}
```

You get performance that beats the goal at nearly 1/20 the latency of
the naive unary tdigest update:
```
observe 1 via online wrapper
                        time:   [42.548 ns 42.801 ns 43.074 ns]
                        change: [-4.4928% -1.7819% +0.4381%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
```

If you have `mut` you can further improve to better than 1/25 the naive
strategy for unary tdigest updates:
```
observe 1 via online wrapper &mut
                        time:   [33.226 ns 33.430 ns 33.650 ns]
                        change: [-1.6854% -0.0649% +1.4163%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
```